### PR TITLE
stream: correctly continue to call ReadSlice on bufio.ErrBufferFull

### DIFF
--- a/internal/testdata/input.go
+++ b/internal/testdata/input.go
@@ -18,6 +18,7 @@ var testData = []string{
 
 const inputLineCount = 100000
 
+// GenerateInput creates arbitrary input with inputLineCount lines.
 func GenerateInput() (io.Reader, func()) {
 	inputLines := make([]string, inputLineCount)
 	for l := 0; l < inputLineCount; l++ {
@@ -27,6 +28,7 @@ func GenerateInput() (io.Reader, func()) {
 	return r, func() { r.Seek(0, 0) }
 }
 
+// GenerateLargeInput creates arbitrary input with inputLineCount * x lines.
 func GenerateLargeInput(x int) (io.Reader, int, func()) {
 	wantCount := inputLineCount * x
 	inputLines := make([]string, wantCount)
@@ -36,4 +38,16 @@ func GenerateLargeInput(x int) (io.Reader, int, func()) {
 	data := strings.Join(inputLines, "\n")
 	r := bytes.NewReader([]byte(data))
 	return r, len(data), func() { r.Seek(0, 0) }
+}
+
+// GenerateWideInput creates a single-line input with inputLineCount * x characters.
+func GenerateWideInput(x int) (io.Reader, int, func()) {
+	wantWidth := inputLineCount * x
+	var inputData string
+	for len(inputData) < wantWidth {
+		inputData += (" " + testData[len(inputData)%len(testData)])
+	}
+	data := strings.Join([]string{inputData}, "\n")
+	r := strings.NewReader(data)
+	return r, len(inputData), func() { r.Seek(0, 0) }
 }

--- a/internal_test.go
+++ b/internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.bobheadxi.dev/streamline/internal/testdata"
 )
 
 func TestNew(t *testing.T) {
@@ -23,5 +24,29 @@ func TestNew(t *testing.T) {
 		r := strings.NewReader("hello world")
 		s := New(r)
 		assert.NotEqual(t, r, s.reader)
+	})
+}
+
+func TestStreamLoad(t *testing.T) {
+	t.Run("large input", func(t *testing.T) {
+		t.Parallel()
+
+		input, size, _ := testdata.GenerateLargeInput(10)
+		s := New(input)
+
+		data, err := s.Bytes()
+		assert.NoError(t, err)
+		assert.Equal(t, size, len(data))
+	})
+
+	t.Run("wide input", func(t *testing.T) {
+		t.Parallel()
+
+		input, size, _ := testdata.GenerateWideInput(10)
+		s := New(input)
+
+		data, err := s.Bytes()
+		assert.NoError(t, err)
+		assert.Equal(t, size, len(data))
 	})
 }


### PR DESCRIPTION
This is [effectively what `(*bufio.Reader).ReadLine` does](https://cs.opensource.google/go/go/+/refs/tags/go1.21.6:src/bufio/bufio.go;l=407-409) - `ReadSlice` provides a partial line if its internal buffer is full, as indicated by `bufio.ErrBufferFull`. If we get this, we're supposed to just keep calling `ReadSlice` until we have a complete line.

Before I applied this fix, I was able to reproduce #3 with the `wide input` test case - after this fix, the tests pass as expected.

Closes #3 